### PR TITLE
Separated JavaFX and CLI runners

### DIFF
--- a/src/main/java/com/buschmais/sarf/SARFCLIRunner.java
+++ b/src/main/java/com/buschmais/sarf/SARFCLIRunner.java
@@ -1,0 +1,74 @@
+package com.buschmais.sarf;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import com.buschmais.sarf.framework.ClassificationRunner;
+import com.buschmais.xo.api.XOManager;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * Created by steph on 04.05.2017.
+ */
+@SpringBootApplication
+public class SARFCLIRunner {
+
+    private static final Logger LOG = LogManager.getLogger(SARFCLIRunner.class);
+
+    public static void main(String[] args) throws URISyntaxException {
+        ConfigurableApplicationContext springContext = SpringApplication.run(SARFCLIRunner.class);
+
+        Options options = new Options();
+        Option store = new Option("s", "store", true, "Neo4J Graph Store Path");
+        store.setRequired(true);
+        Option config = new Option("c", "conf", true, "Configuration File Path");
+        config.setRequired(false);
+        Option load = new Option("l", "load", true, "Iteration to load");
+        load.setRequired(false);
+        Option bench = new Option("b", "bench", true, "Benchmark File for Genetic Algorithm");
+        bench.setRequired(false);
+        OptionGroup group = new OptionGroup();
+        group.addOption(config);
+        group.addOption(load);
+        group.addOption(bench);
+        group.setRequired(false);
+        options.addOption(store);
+        options.addOptionGroup(group);
+
+        CommandLineParser parser = new DefaultParser();
+        HelpFormatter formatter = new HelpFormatter();
+        try {
+            CommandLine cmd = parser.parse(options, args);
+            URI storeUri = new URI(cmd.getOptionValue("s"));
+            URL configUrl = cmd.hasOption("c") ? new URL(cmd.getOptionValue("c")) : null;
+            Integer iteration = cmd.hasOption("l") ? Integer.valueOf(cmd.getOptionValue("l")) : null;
+            URL benchUrl = cmd.hasOption("b") ? new URL(cmd.getOptionValue("b")) : null;
+
+            springContext.getBean(XOManager.class, storeUri);
+            ClassificationRunner runner = springContext.getBean(ClassificationRunner.class);
+            runner.startNewIteration(configUrl);
+        } catch (ParseException e) {
+            LOG.error(e.getMessage());
+            formatter.printHelp("java -jar sarf.jar", options);
+            System.exit(1);
+        } catch (MalformedURLException e) {
+            LOG.error("Configuration file not found");
+            System.exit(1);
+        }
+        System.exit(0);
+    }
+}

--- a/src/main/java/com/buschmais/sarf/SARFRunner.java
+++ b/src/main/java/com/buschmais/sarf/SARFRunner.java
@@ -1,82 +1,26 @@
 package com.buschmais.sarf;
 
-import com.buschmais.xo.api.XOManager;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Lazy;
-
-import java.net.URISyntaxException;
 
 /**
  * Created by steph on 04.05.2017.
  */
 @SpringBootApplication
-public class SARFRunner extends Application{
-
-    private static final Logger LOG = LogManager.getLogger(SARFRunner.class);
-
-    @Autowired
-    private BeanFactory beanFactory;
-
-    @Autowired @Lazy
-    private XOManager xoManager;
+public class SARFRunner extends Application {
 
     private ConfigurableApplicationContext springContext;
 
     private Parent rootNode;
 
-    public static void main(String[] args) throws URISyntaxException {
-        if (args.length == 0) {
-            launch(SARFRunner.class, args);
-        } else {/*
-            Options options = new Options();
-            Option store = new Option("s", "store", true, "Neo4J Graph Store Path");
-            store.setRequired(true);
-            Option config = new Option("c", "conf", true, "Configuration File Path");
-            config.setRequired(false);
-            Option load = new Option("l", "load", true, "Iteration to load");
-            load.setRequired(false);
-            Option bench = new Option("b", "bench", true, "Benchmark File for Genetic Algorithm");
-            bench.setRequired(false);
-            OptionGroup group = new OptionGroup();
-            group.addOption(config);
-            group.addOption(load);
-            group.addOption(bench);
-            group.setRequired(false);
-            options.addOption(store);
-            options.addOptionGroup(group);
-            ClassificationRunner runner = ClassificationRunner.getInstance();
-            CommandLineParser parser = new DefaultParser();
-            HelpFormatter formatter = new HelpFormatter();
-            CommandLine cmd = null;
-            try {
-                cmd = parser.parse(options, args);
-                URI storeUri = new URI(cmd.getOptionValue("s"));
-                URL configUrl = cmd.hasOption("c") ? new URL(cmd.getOptionValue("c")) : null;
-                Integer iteration = cmd.hasOption("l") ? Integer.valueOf(cmd.getOptionValue("l")) : null;
-                URL benchUrl = cmd.hasOption("b") ? new URL(cmd.getOptionValue("b")) : null;
-                //DatabaseHelper.setUpDB(storeUri); todo fix
-                //runner.run(configUrl, benchUrl, iteration);
-                //DatabaseHelper.stopDB();
-            } catch (ParseException e) {
-                LOG.error(e.getMessage());
-                formatter.printHelp("java -jar sarf.jar", options);
-                System.exit(1);
-            } catch (MalformedURLException e) {
-                LOG.error("Configuration file not found");
-                System.exit(1);
-            }*/
-        }
+    public static void main(String[] args) {
+        launch(SARFRunner.class, args);
     }
 
     @Override

--- a/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationDescriptor.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationDescriptor.java
@@ -27,13 +27,13 @@ public interface ClassificationConfigurationDescriptor extends SARFDescriptor {
 
     Integer getIteration();
 
-    void setDecomposition(String decomposition);
+    void setDecomposition(Decomposition decomposition);
 
-    String getDecomposition();
+    Decomposition getDecomposition();
 
-    void setOptimization(String optimization);
+    void setOptimization(Optimization optimization);
 
-    String getOptimization();
+    Optimization getOptimization();
 
     void setGenerations(Integer generations);
 

--- a/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationExecutor.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationExecutor.java
@@ -3,6 +3,7 @@ package com.buschmais.sarf.framework.configuration;
 import com.buschmais.jqassistant.plugin.java.api.model.TypeDescriptor;
 import com.buschmais.sarf.SARFRunner;
 import com.buschmais.sarf.framework.metamodel.ComponentDescriptor;
+import com.buschmais.sarf.framework.repository.AnnotationResolver;
 import com.buschmais.sarf.framework.repository.ComponentRepository;
 import com.buschmais.sarf.framework.repository.TypeRepository;
 import com.buschmais.sarf.plugin.api.ExecutedBy;
@@ -10,6 +11,7 @@ import com.buschmais.sarf.plugin.api.Executor;
 import com.buschmais.sarf.plugin.api.criterion.ClassificationCriterionDescriptor;
 import com.buschmais.sarf.plugin.api.criterion.ClassificationCriterionExecutor;
 import com.buschmais.sarf.plugin.api.criterion.RuleBasedCriterionDescriptor;
+import com.buschmais.sarf.plugin.api.criterion.RuleBasedCriterionExecutor;
 import com.buschmais.sarf.plugin.chorddiagram.ChordDiagramExporter;
 import com.buschmais.sarf.plugin.cohesion.CohesionCriterionDescriptor;
 import com.buschmais.sarf.plugin.cohesion.CohesionCriterionExecutor;
@@ -74,12 +76,18 @@ public class ClassificationConfigurationExecutor implements Executor<Classificat
         Set<ClassificationCriterionDescriptor> classificationCriteria = executableDescriptor.getClassificationCriteria();
         for (ClassificationCriterionDescriptor cC : classificationCriteria) {
             if (cC instanceof RuleBasedCriterionDescriptor) {
-                Class<? extends Executor> executorClass = cC.getClass().getAnnotation(ExecutedBy.class).value();
+                ExecutedBy executedBy = AnnotationResolver.resolveAnnotation(cC.getClass(), ExecutedBy.class);
+                Class<? extends Executor> executorClass = executedBy.value();
                 if (executorClass.isAssignableFrom(ClassificationCriterionExecutor.class)) {
                     @SuppressWarnings("unchecked")
                     ClassificationCriterionExecutor<ClassificationCriterionDescriptor> executor =
                         this.beanFactory.getBean((Class<ClassificationCriterionExecutor>) executorClass);
                     components.addAll(executor.execute(cC));
+                } else if (executorClass.isAssignableFrom(RuleBasedCriterionExecutor.class)) {
+                    @SuppressWarnings("unchecked")
+                    RuleBasedCriterionExecutor<RuleBasedCriterionDescriptor> executor =
+                        this.beanFactory.getBean((Class<RuleBasedCriterionExecutor>) executorClass);
+                    components.addAll(executor.execute((RuleBasedCriterionDescriptor) cC));
                 }
             } else {
                 cohesionCriterionDescriptor = (CohesionCriterionDescriptor) cC;

--- a/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationMaterializer.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationMaterializer.java
@@ -1,9 +1,15 @@
 package com.buschmais.sarf.framework.configuration;
 
 import com.buschmais.sarf.framework.metamodel.ComponentDescriptor;
+import com.buschmais.sarf.framework.metamodel.ComponentXmlMapper;
+import com.buschmais.sarf.framework.repository.AnnotationResolver;
 import com.buschmais.sarf.plugin.api.*;
 import com.buschmais.sarf.plugin.api.criterion.RuleBasedCriterionDescriptor;
 import com.buschmais.sarf.plugin.api.criterion.RuleDescriptor;
+import com.buschmais.sarf.plugin.api.criterion.RuleXmlMapper;
+import com.buschmais.sarf.plugin.packagenaming.PackageNamingCriterionDescriptor;
+import com.buschmais.sarf.plugin.packagenaming.PackageNamingRuleDescriptor;
+import com.buschmais.sarf.plugin.packagenaming.PackageNamingRuleXmlMapper;
 import com.buschmais.xo.api.XOManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,100 +56,67 @@ public class ClassificationConfigurationMaterializer {
         classificationConfigurationDescriptor.setOptimization(mapper.optimization);
 
         // materialize components
-        Set<ComponentDescriptor> componentDescriptors = mapper.getDefinedComponents().stream()
-            .map(m -> (ComponentDescriptor) genericMaterialize(m))
-            .collect(Collectors.toSet());
+        Set<ComponentDescriptor> componentDescriptors =
+            mapper.definedComponents.stream().map(this::materializeComponent).collect(Collectors.toSet());
         classificationConfigurationDescriptor.getDefinedComponents().addAll(componentDescriptors);
         // create criteria for all rules
-        Map<Class<? extends RuleBasedCriterionDescriptor>, Set<RuleDescriptor>> aggregatedRules = new HashMap<>();
+        Map<Class<? extends RuleBasedCriterionDescriptor>, Set<RuleDescriptor>> aggregatedRules =
+            new HashMap<>();
         for (RuleDescriptor ruleDescriptor : flattenRules(componentDescriptors)) {
-            ContainedIn containedIn = ruleDescriptor.getClass().getAnnotation(ContainedIn.class);
+            ContainedIn containedIn =
+                AnnotationResolver.resolveAnnotation(ruleDescriptor.getClass(), ContainedIn.class);
             aggregatedRules.putIfAbsent(containedIn.value(), new HashSet<>());
             aggregatedRules.get(containedIn.value()).add(ruleDescriptor);
         }
         aggregatedRules.forEach((k, v) -> {
-            RuleBasedCriterionDescriptor<RuleDescriptor> classificationCriterion = this.xoManager.create(k);
+            RuleBasedCriterionDescriptor classificationCriterion = this.xoManager.create(k);
             classificationCriterion.getRules().addAll(v);
+            classificationConfigurationDescriptor.getClassificationCriteria().add(classificationCriterion);
         });
         return classificationConfigurationDescriptor;
     }
 
-    private SARFDescriptor genericMaterialize(XmlMapper mapper) {
-        if (mapper.getClass().isAnnotationPresent(Materializable.class)) {
-            Class<? extends SARFDescriptor> descriptorClass = mapper.getClass().getAnnotation(Materializable.class).value();
-            SARFDescriptor descriptor = this.xoManager.create(descriptorClass);
-            for (Field f : mapper.getClass().getDeclaredFields()) {
-                if (f.isAnnotationPresent(XmlAttribute.class)) {
-                    // candidate field to persist found, look for setter
-                    char[] setterName = ("set" + f.getName()).toCharArray();
-                    setterName[2] = Character.toUpperCase(setterName[2]);
-                    try {
-                        Method setter = descriptorClass.getMethod(new String(setterName), f.getType());
-                        setter.setAccessible(true);
-                        f.setAccessible(true);
-                        setter.invoke(descriptor, f.get(mapper));
-                        f.setAccessible(false);
-                        setter.setAccessible(false);
-                    } catch (NoSuchMethodException e) {
-                        throw new MethodNotFoundException(descriptor.getClass().getName() + "has no setter for field " + f.getName() +
-                            "(" + new String(setterName) + "(" + f.getType().getName() + "))");
-                    } catch (IllegalAccessException | InvocationTargetException e) {
-                        // will not occur as everything necessary was checked
-                        e.printStackTrace();
-                    }
-                } else if (f.isAnnotationPresent(XmlElement.class)) {
-                    // must be materialized, can either be a collection or a single object
-                    if (Collection.class.isAssignableFrom(f.getType())) {
-                        char[] getterName = ("get" + f.getName()).toCharArray();
-                        getterName[2] = Character.toUpperCase(getterName[2]);
-                        try {
-                            Method getter = descriptorClass.getDeclaredMethod(new String(getterName));
-                            getter.setAccessible(true);
-                            f.setAccessible(true);
-                            @SuppressWarnings("unchecked")
-                            Collection<? extends XmlMapper> items = (Collection<? extends XmlMapper>) f.get(mapper);
-                            @SuppressWarnings("unchecked")
-                            Collection<SARFDescriptor> col = (Collection<SARFDescriptor>) getter.invoke(descriptor);
-                            items.forEach(i -> col.add(genericMaterialize(i)));
-                            f.setAccessible(false);
-                            getter.setAccessible(false);
-                        } catch (NoSuchMethodException e) {
-                            throw new MethodNotFoundException(descriptor.getClass().getName() + "has no getter for field " + f.getName() +
-                                "(" + new String(getterName) + ")");
-                        } catch (IllegalAccessException | InvocationTargetException e) {
-                            // will not occur as everything necessary was checked
-                            e.printStackTrace();
-                        }
-                    } else {
-                        char[] setterName = ("set" + f.getName()).toCharArray();
-                        setterName[2] = Character.toUpperCase(setterName[2]);
-                        try {
-                            Method setter = descriptorClass.getDeclaredMethod(new String(setterName));
-                            setter.setAccessible(true);
-                            f.setAccessible(true);
-                            XmlMapper childMapper = (XmlMapper) f.get(mapper);
-                            setter.invoke(descriptor, genericMaterialize(childMapper));
-                            f.setAccessible(false);
-                            setter.setAccessible(false);
-                        } catch (NoSuchMethodException e) {
-                            throw new MethodNotFoundException(descriptorClass.getName() + "has no setter for field " + f.getName() +
-                                "(" + new String(setterName) + "(" + f.getType().getName() + "))");
-                        } catch (IllegalAccessException | InvocationTargetException e) {
-                            e.printStackTrace();
-                        } catch (ClassCastException e) {
-                            throw new ClassCastException(f.getName() + " does not implement interface " + XmlMapper.class);
-                        }
-                    }
-                }
-            }
-            return descriptor;
-        } else {
-            throw new NotMaterializableException(mapper.getClass().getName() + "is not materializable");
+    private ComponentDescriptor materializeComponent(ComponentXmlMapper mapper) {
+        ComponentDescriptor component = this.xoManager.create(ComponentDescriptor.class);
+        component.setName(mapper.name);
+        component.setShape(mapper.shape);
+
+        if (mapper.containedComponents != null) {
+            component.getContainedComponents().addAll(
+                mapper.containedComponents.stream().map(this::materializeComponent)
+                    .collect(Collectors.toList()));
         }
+
+        if (mapper.identifyingRules != null) {
+            component.getIdentifyingRules().addAll(
+                mapper.identifyingRules.stream().map(rule -> this.materializeRule(rule, component))
+                    .collect(Collectors.toList()));
+        }
+
+        return component;
+    }
+
+    private RuleDescriptor materializeRule(RuleXmlMapper mapper, ComponentDescriptor parent) {
+        Materializable materializable =
+            AnnotationResolver.resolveAnnotation(mapper.getClass(), Materializable.class);
+        Class<? extends RuleDescriptor> descriptorClass =
+            (Class<? extends RuleDescriptor>) materializable.value();
+
+        RuleDescriptor rule = this.xoManager.create(descriptorClass);
+        rule.setName(parent.getName());
+        rule.setShape(parent.getShape());
+        rule.setRule(mapper.rule);
+        rule.setWeight(mapper.weight);
+        return rule;
     }
 
     private Set<RuleDescriptor> flattenRules(Set<ComponentDescriptor> components) {
-        Set<RuleDescriptor> rules = new TreeSet<>();
+        Set<RuleDescriptor> rules = new TreeSet<>((r1, r2) -> {
+            if (!r1.getShape().equals(r2.getShape())) return r1.getShape().compareTo(r2.getShape());
+            if (!r1.getName().equals(r2.getName())) return r1.getName().compareTo(r2.getName());
+            if (!r1.getRule().equals(r2.getRule())) return r1.getRule().compareTo(r2.getRule());
+            return (int) (r1.getWeight() - r2.getWeight());
+        });
         for (ComponentDescriptor component : components) {
             rules.addAll(component.getIdentifyingRules());
             rules.addAll(flattenRules(component.getContainedComponents()));

--- a/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationMaterializer.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationMaterializer.java
@@ -37,29 +37,18 @@ public class ClassificationConfigurationMaterializer {
     }
 
     public ClassificationConfigurationDescriptor materialize(ClassificationConfigurationXmlMapper mapper) {
-        this.xoManager.currentTransaction().begin();
         ClassificationConfigurationDescriptor classificationConfigurationDescriptor =
             this.xoManager.create(ClassificationConfigurationDescriptor.class);
         // materialize all simple fields
-        for (Field f : mapper.getClass().getDeclaredFields()) {
-            f.setAccessible(true);
-            if (!f.getName().equals("definedComponents")) {
-                char[] setterName = ("set" + f.getName()).toCharArray();
-                setterName[2] = Character.toUpperCase(setterName[2]);
-                try {
-                    Method setter = classificationConfigurationDescriptor.getClass().getMethod(new String(setterName), f.getType());
-                    setter.setAccessible(true);
-                    setter.invoke(classificationConfigurationDescriptor, f.get(mapper));
-                    setter.setAccessible(false);
-                } catch (NoSuchMethodException e) {
-                    throw new MethodNotFoundException(classificationConfigurationDescriptor.getClass().getName() +
-                        "has no setter for field " + f.getName() + "(" + new String(setterName) + "(" + f.getType().getName() + "))");
-                } catch (IllegalAccessException | InvocationTargetException e) {
-                    e.printStackTrace();
-                }
-            }
-            f.setAccessible(false);
-        }
+        classificationConfigurationDescriptor.setIteration(mapper.iteration);
+        classificationConfigurationDescriptor.setBasePackage(mapper.basePackage);
+        classificationConfigurationDescriptor.setTypeName(mapper.typeName);
+        classificationConfigurationDescriptor.setArtifact(mapper.artifact);
+        classificationConfigurationDescriptor.setGenerations(mapper.generations);
+        classificationConfigurationDescriptor.setPopulationSize(mapper.populationSize);
+        classificationConfigurationDescriptor.setDecomposition(mapper.decomposition);
+        classificationConfigurationDescriptor.setOptimization(mapper.optimization);
+
         // materialize components
         Set<ComponentDescriptor> componentDescriptors = mapper.getDefinedComponents().stream()
             .map(m -> (ComponentDescriptor) genericMaterialize(m))
@@ -76,7 +65,6 @@ public class ClassificationConfigurationMaterializer {
             RuleBasedCriterionDescriptor<RuleDescriptor> classificationCriterion = this.xoManager.create(k);
             classificationCriterion.getRules().addAll(v);
         });
-        this.xoManager.currentTransaction().commit();
         return classificationConfigurationDescriptor;
     }
 

--- a/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationXmlMapper.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationXmlMapper.java
@@ -1,13 +1,14 @@
 package com.buschmais.sarf.framework.configuration;
 
+import java.util.HashSet;
+import java.util.Set;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
 import com.buschmais.sarf.framework.metamodel.ComponentXmlMapper;
 import com.buschmais.sarf.plugin.api.Materializable;
 import com.buschmais.sarf.plugin.api.XmlMapper;
-import lombok.Getter;
-
-import javax.xml.bind.annotation.*;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * @author Stephan Pirnbaum
@@ -19,7 +20,6 @@ public class ClassificationConfigurationXmlMapper implements XmlMapper{
     @XmlAttribute(name = "iteration")
     public Integer iteration;
 
-    @Getter
     @XmlAttribute(name = "basePackage")
     public String basePackage;
 
@@ -41,7 +41,6 @@ public class ClassificationConfigurationXmlMapper implements XmlMapper{
     @XmlAttribute(name = "optimization")
     public Optimization optimization;
 
-    @Getter
     @XmlElement(name = "Component")
     public Set<ComponentXmlMapper> definedComponents = new HashSet<>();
 

--- a/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationXmlMapper.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationXmlMapper.java
@@ -16,51 +16,33 @@ import java.util.Set;
 @Materializable(ClassificationConfigurationDescriptor.class)
 public class ClassificationConfigurationXmlMapper implements XmlMapper{
 
-    @XmlType
-    @XmlEnum
-    public enum Decomposition {
-        @XmlEnumValue("flat")
-        FLAT,
-        @XmlEnumValue("deep")
-        DEEP;
-    }
-
-    @XmlType
-    @XmlEnum
-    public enum Optimization {
-        @XmlEnumValue("similarity")
-        SIMILARITY,
-        @XmlEnumValue("coupling")
-        COUPLING
-    }
-
     @XmlAttribute(name = "iteration")
-    Integer iteration;
+    public Integer iteration;
 
     @Getter
     @XmlAttribute(name = "basePackage")
-    String basePackage;
+    public String basePackage;
 
     @XmlAttribute(name = "typeName")
-    String typeName;
+    public String typeName;
 
     @XmlAttribute(name = "artifact")
-    String artifact;
+    public String artifact;
 
     @XmlAttribute(name = "generations")
-    Integer generations;
+    public Integer generations;
 
     @XmlAttribute(name = "populationSize")
-    Integer populationSize;
+    public Integer populationSize;
 
     @XmlAttribute(name = "decomposition")
-    private Decomposition decomposition;
+    public Decomposition decomposition;
 
     @XmlAttribute(name = "optimization")
-    private Optimization optimization;
+    public Optimization optimization;
 
     @Getter
     @XmlElement(name = "Component")
-    Set<ComponentXmlMapper> definedComponents = new HashSet<>();
+    public Set<ComponentXmlMapper> definedComponents = new HashSet<>();
 
 }

--- a/src/main/java/com/buschmais/sarf/framework/configuration/Decomposition.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/Decomposition.java
@@ -1,0 +1,12 @@
+package com.buschmais.sarf.framework.configuration;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType
+@XmlEnum
+public enum Decomposition {
+    @XmlEnumValue("flat") FLAT,
+    @XmlEnumValue("deep") DEEP
+}

--- a/src/main/java/com/buschmais/sarf/framework/configuration/Optimization.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/Optimization.java
@@ -1,0 +1,12 @@
+package com.buschmais.sarf.framework.configuration;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType
+@XmlEnum
+public enum Optimization {
+    @XmlEnumValue("similarity") SIMILARITY,
+    @XmlEnumValue("coupling") COUPLING
+}

--- a/src/main/java/com/buschmais/sarf/framework/metamodel/ComponentXmlMapper.java
+++ b/src/main/java/com/buschmais/sarf/framework/metamodel/ComponentXmlMapper.java
@@ -1,5 +1,12 @@
 package com.buschmais.sarf.framework.metamodel;
 
+import java.util.Set;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlID;
+
 import com.buschmais.sarf.plugin.api.Materializable;
 import com.buschmais.sarf.plugin.api.XmlMapper;
 import com.buschmais.sarf.plugin.api.criterion.RuleXmlMapper;
@@ -9,10 +16,6 @@ import com.buschmais.sarf.plugin.dependency.ExtendsRuleXmlMapper;
 import com.buschmais.sarf.plugin.dependency.ImplementsRuleXmlMapper;
 import com.buschmais.sarf.plugin.packagenaming.PackageNamingRuleXmlMapper;
 import com.buschmais.sarf.plugin.typenaming.TypeNamingRuleXmlMapper;
-import lombok.Getter;
-
-import javax.xml.bind.annotation.*;
-import java.util.Set;
 
 /**
  * @author Stephan Pirnbaum
@@ -20,21 +23,17 @@ import java.util.Set;
 @Materializable(ComponentDescriptor.class)
 public class ComponentXmlMapper implements XmlMapper {
 
-    @Getter
     @XmlID
     @XmlAttribute(name = "shape")
-    private String shape;
+    public String shape;
 
-    @Getter
     @XmlID
     @XmlAttribute(name = "name")
-    private String name;
+    public String name;
 
-    @Getter
     @XmlElement(name = "Component")
-    private Set<ComponentXmlMapper> containedComponents;
+    public Set<ComponentXmlMapper> containedComponents;
 
-    @Getter
     @XmlElementWrapper(name = "Rules")
     @XmlElements(
             {
@@ -46,6 +45,6 @@ public class ComponentXmlMapper implements XmlMapper {
                     @XmlElement(name = "Implements", type = ImplementsRuleXmlMapper.class)
             }
     )
-    Set<RuleXmlMapper> identifyingRules;
+    public Set<RuleXmlMapper> identifyingRules;
 
 }

--- a/src/main/java/com/buschmais/sarf/framework/repository/AnnotationResolver.java
+++ b/src/main/java/com/buschmais/sarf/framework/repository/AnnotationResolver.java
@@ -1,0 +1,41 @@
+package com.buschmais.sarf.framework.repository;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * Resolves annotations, especially on interfaces which are managed by XOManager.
+ */
+public class AnnotationResolver {
+
+    private static final String EXCEPTION_MESSAGE = "Annotation %s not found on %s or one of its interfaces.";
+
+    /**
+     * Resolve an annotation on the class itself and all of its interfaces.
+     * If the annotation is present on more than one interfaces, the first occurrence is returned.
+     *
+     * @param searchClass     class to be searched
+     * @param annotationClass class of the annotation
+     * @param <A>             type of the annotation
+     * @return the annotation, or raises an exception.
+     */
+    public static <A extends Annotation> A resolveAnnotation(Class<?> searchClass, Class<A> annotationClass) {
+        A annotationOnType = searchClass.getAnnotation(annotationClass);
+        if (annotationOnType != null) {
+            return annotationOnType;
+        }
+        // Search interfaces
+        for (Class<?> searchInterface : searchClass.getInterfaces()) {
+            A annotationOnInterface = resolveAnnotation(searchInterface, annotationClass);
+            if (annotationOnInterface != null) {
+                return annotationOnInterface;
+            }
+        }
+
+        throw new IllegalArgumentException(
+            String.format(EXCEPTION_MESSAGE, annotationClass.getSimpleName(), searchClass.getSimpleName()));
+    }
+
+    private AnnotationResolver() {
+    }
+
+}

--- a/src/main/java/com/buschmais/sarf/framework/ui/ConfigurationDialogController.java
+++ b/src/main/java/com/buschmais/sarf/framework/ui/ConfigurationDialogController.java
@@ -1,6 +1,9 @@
 package com.buschmais.sarf.framework.ui;
 
 import com.buschmais.sarf.framework.ClassificationRunner;
+import com.buschmais.sarf.framework.configuration.ClassificationConfigurationXmlMapper;
+import com.buschmais.sarf.framework.configuration.Decomposition;
+import com.buschmais.sarf.framework.configuration.Optimization;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -72,16 +75,23 @@ public class ConfigurationDialogController extends AbstractController {
     private void execute() {
         this.execute.setDisable(true);
         try {
-            this.classificationRunner.startNewIteration(
-                    1, this.artifact.getText(), this.basePackage.getText(), this.typeName.getText(),
-                    Integer.valueOf(this.generations.getText()), Integer.valueOf(this.populationSize.getText()), true, false
-            );
+            ClassificationConfigurationXmlMapper classificationConfiguration =
+                new ClassificationConfigurationXmlMapper();
+            classificationConfiguration.iteration = 1;
+            classificationConfiguration.artifact = this.artifact.getText();
+            classificationConfiguration.basePackage = this.basePackage.getText();
+            classificationConfiguration.typeName = this.typeName.getText();
+            classificationConfiguration.generations = Integer.valueOf(this.generations.getText());
+            classificationConfiguration.populationSize = Integer.valueOf(this.populationSize.getText());
+            classificationConfiguration.decomposition = Decomposition.DEEP;
+            classificationConfiguration.optimization = Optimization.COUPLING;
+
+            this.classificationRunner.startNewIteration(classificationConfiguration);
         } catch (Exception e) {
             e.printStackTrace();
             showExceptionDialog("Execution Error", "An error occured during decomposing the system!", "", e);
         }
         this.execute.setDisable(false);
     }
-
 
 }

--- a/src/main/java/com/buschmais/sarf/plugin/api/ContainedIn.java
+++ b/src/main/java/com/buschmais/sarf/plugin/api/ContainedIn.java
@@ -2,10 +2,12 @@ package com.buschmais.sarf.plugin.api;
 
 import com.buschmais.sarf.plugin.api.criterion.RuleBasedCriterionDescriptor;
 
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface ContainedIn {
     Class<? extends RuleBasedCriterionDescriptor> value();
 }

--- a/src/main/java/com/buschmais/sarf/plugin/api/criterion/RuleXmlMapper.java
+++ b/src/main/java/com/buschmais/sarf/plugin/api/criterion/RuleXmlMapper.java
@@ -1,47 +1,18 @@
 package com.buschmais.sarf.plugin.api.criterion;
 
-import com.buschmais.sarf.framework.metamodel.ComponentXmlMapper;
-import com.buschmais.sarf.plugin.api.XmlMapper;
-import lombok.*;
-
-import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlAttribute;
+
+import com.buschmais.sarf.plugin.api.XmlMapper;
 
 /**
  * @author Stephan Pirnbaum
  */
-@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
-@AllArgsConstructor
-@EqualsAndHashCode
-public abstract class RuleXmlMapper implements XmlMapper, Comparable<RuleXmlMapper> {
+public abstract class RuleXmlMapper implements XmlMapper {
 
-    @Getter
-    @Setter
-    String shape;
-
-    @Getter
-    @Setter
-    String name;
-
-    @Getter
     @XmlAttribute(name = "weight")
-    double weight;
+    public double weight;
 
-    @Getter
     @XmlAttribute(name = "rule")
-    protected String rule;
+    public String rule;
 
-    @Override
-    public int compareTo(RuleXmlMapper o) {
-        if (!shape.equals(o.getShape())) return shape.compareTo(o.getShape());
-        if (!name.equals(o.getName())) return name.compareTo(o.getName());
-        if (!rule.equals(o.getRule())) return rule.compareTo(o.getRule());
-        return (int) (weight - o.getWeight());
-    }
-
-    @SuppressWarnings("unused")
-    public void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
-        this.shape = ((ComponentXmlMapper) parent).getShape();
-        this.name = ((ComponentXmlMapper) parent).getName();
-    }
 }

--- a/src/main/java/com/buschmais/sarf/plugin/cohesion/CohesionCriterionExecutor.java
+++ b/src/main/java/com/buschmais/sarf/plugin/cohesion/CohesionCriterionExecutor.java
@@ -3,6 +3,8 @@ package com.buschmais.sarf.plugin.cohesion;
 import com.buschmais.jqassistant.plugin.java.api.model.TypeDescriptor;
 import com.buschmais.sarf.framework.configuration.ClassificationConfigurationDescriptor;
 import com.buschmais.sarf.framework.configuration.ClassificationConfigurationRepository;
+import com.buschmais.sarf.framework.configuration.Decomposition;
+import com.buschmais.sarf.framework.configuration.Optimization;
 import com.buschmais.sarf.framework.metamodel.ComponentDescriptor;
 import com.buschmais.sarf.framework.repository.ComponentRepository;
 import com.buschmais.sarf.framework.repository.TypeRepository;
@@ -46,8 +48,8 @@ public final class CohesionCriterionExecutor implements ClassificationCriterionE
             this.xOManager.getRepository(ClassificationConfigurationRepository.class);
         ClassificationConfigurationDescriptor currentConfiguration = classificationConfigurationRepository.getCurrentConfiguration();
         Integer iteration = currentConfiguration.getIteration();
-        boolean similarityBased = currentConfiguration.getOptimization().equals("similarity");
-        boolean hierarchical = currentConfiguration.getDecomposition().equals("deep");
+        boolean similarityBased = currentConfiguration.getOptimization() == Optimization.SIMILARITY;
+        boolean hierarchical = currentConfiguration.getDecomposition() == Decomposition.DEEP;
         Integer generations = currentConfiguration.getGenerations();
         Integer populationSize = currentConfiguration.getPopulationSize();
         Map<Long, Set<Long>> components = null; // todo get from database

--- a/src/main/java/com/buschmais/sarf/plugin/cohesion/evolution/Partitioner.java
+++ b/src/main/java/com/buschmais/sarf/plugin/cohesion/evolution/Partitioner.java
@@ -75,6 +75,7 @@ public class Partitioner {
                         return s1;
                     });
         }
+        System.out.print("\n");
         return identifiedComponents;
 
     }


### PR DESCRIPTION
Also streamlined preparation & configuration code and made sure that both runners call the same pieces of code (most notably resetting the SARF data before a new run). 
This is an important prerequisite for passing a-priori knowledge to the CLI runner.