### PR TITLE
Separated JavaFX and CLI runners

### DIFF
--- a/src/main/java/com/buschmais/sarf/SARFCLIRunner.java
+++ b/src/main/java/com/buschmais/sarf/SARFCLIRunner.java
@@ -1,0 +1,74 @@
+package com.buschmais.sarf;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import com.buschmais.sarf.framework.ClassificationRunner;
+import com.buschmais.xo.api.XOManager;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * Created by steph on 04.05.2017.
+ */
+@SpringBootApplication
+public class SARFCLIRunner {
+
+    private static final Logger LOG = LogManager.getLogger(SARFCLIRunner.class);
+
+    public static void main(String[] args) throws URISyntaxException {
+        ConfigurableApplicationContext springContext = SpringApplication.run(SARFCLIRunner.class);
+
+        Options options = new Options();
+        Option store = new Option("s", "store", true, "Neo4J Graph Store Path");
+        store.setRequired(true);
+        Option config = new Option("c", "conf", true, "Configuration File Path");
+        config.setRequired(false);
+        Option load = new Option("l", "load", true, "Iteration to load");
+        load.setRequired(false);
+        Option bench = new Option("b", "bench", true, "Benchmark File for Genetic Algorithm");
+        bench.setRequired(false);
+        OptionGroup group = new OptionGroup();
+        group.addOption(config);
+        group.addOption(load);
+        group.addOption(bench);
+        group.setRequired(false);
+        options.addOption(store);
+        options.addOptionGroup(group);
+
+        CommandLineParser parser = new DefaultParser();
+        HelpFormatter formatter = new HelpFormatter();
+        try {
+            CommandLine cmd = parser.parse(options, args);
+            URI storeUri = new URI(cmd.getOptionValue("s"));
+            URL configUrl = cmd.hasOption("c") ? new URL(cmd.getOptionValue("c")) : null;
+            Integer iteration = cmd.hasOption("l") ? Integer.valueOf(cmd.getOptionValue("l")) : null;
+            URL benchUrl = cmd.hasOption("b") ? new URL(cmd.getOptionValue("b")) : null;
+
+            springContext.getBean(XOManager.class, storeUri);
+            ClassificationRunner runner = springContext.getBean(ClassificationRunner.class);
+            runner.startNewIteration(configUrl);
+        } catch (ParseException e) {
+            LOG.error(e.getMessage());
+            formatter.printHelp("java -jar sarf.jar", options);
+            System.exit(1);
+        } catch (MalformedURLException e) {
+            LOG.error("Configuration file not found");
+            System.exit(1);
+        }
+        System.exit(0);
+    }
+}

--- a/src/main/java/com/buschmais/sarf/SARFRunner.java
+++ b/src/main/java/com/buschmais/sarf/SARFRunner.java
@@ -1,82 +1,26 @@
 package com.buschmais.sarf;
 
-import com.buschmais.xo.api.XOManager;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Lazy;
-
-import java.net.URISyntaxException;
 
 /**
  * Created by steph on 04.05.2017.
  */
 @SpringBootApplication
-public class SARFRunner extends Application{
-
-    private static final Logger LOG = LogManager.getLogger(SARFRunner.class);
-
-    @Autowired
-    private BeanFactory beanFactory;
-
-    @Autowired @Lazy
-    private XOManager xoManager;
+public class SARFRunner extends Application {
 
     private ConfigurableApplicationContext springContext;
 
     private Parent rootNode;
 
-    public static void main(String[] args) throws URISyntaxException {
-        if (args.length == 0) {
-            launch(SARFRunner.class, args);
-        } else {/*
-            Options options = new Options();
-            Option store = new Option("s", "store", true, "Neo4J Graph Store Path");
-            store.setRequired(true);
-            Option config = new Option("c", "conf", true, "Configuration File Path");
-            config.setRequired(false);
-            Option load = new Option("l", "load", true, "Iteration to load");
-            load.setRequired(false);
-            Option bench = new Option("b", "bench", true, "Benchmark File for Genetic Algorithm");
-            bench.setRequired(false);
-            OptionGroup group = new OptionGroup();
-            group.addOption(config);
-            group.addOption(load);
-            group.addOption(bench);
-            group.setRequired(false);
-            options.addOption(store);
-            options.addOptionGroup(group);
-            ClassificationRunner runner = ClassificationRunner.getInstance();
-            CommandLineParser parser = new DefaultParser();
-            HelpFormatter formatter = new HelpFormatter();
-            CommandLine cmd = null;
-            try {
-                cmd = parser.parse(options, args);
-                URI storeUri = new URI(cmd.getOptionValue("s"));
-                URL configUrl = cmd.hasOption("c") ? new URL(cmd.getOptionValue("c")) : null;
-                Integer iteration = cmd.hasOption("l") ? Integer.valueOf(cmd.getOptionValue("l")) : null;
-                URL benchUrl = cmd.hasOption("b") ? new URL(cmd.getOptionValue("b")) : null;
-                //DatabaseHelper.setUpDB(storeUri); todo fix
-                //runner.run(configUrl, benchUrl, iteration);
-                //DatabaseHelper.stopDB();
-            } catch (ParseException e) {
-                LOG.error(e.getMessage());
-                formatter.printHelp("java -jar sarf.jar", options);
-                System.exit(1);
-            } catch (MalformedURLException e) {
-                LOG.error("Configuration file not found");
-                System.exit(1);
-            }*/
-        }
+    public static void main(String[] args) {
+        launch(SARFRunner.class, args);
     }
 
     @Override

--- a/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationDescriptor.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationDescriptor.java
@@ -27,13 +27,13 @@ public interface ClassificationConfigurationDescriptor extends SARFDescriptor {
 
     Integer getIteration();
 
-    void setDecomposition(String decomposition);
+    void setDecomposition(Decomposition decomposition);
 
-    String getDecomposition();
+    Decomposition getDecomposition();
 
-    void setOptimization(String optimization);
+    void setOptimization(Optimization optimization);
 
-    String getOptimization();
+    Optimization getOptimization();
 
     void setGenerations(Integer generations);
 

--- a/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationMaterializer.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationMaterializer.java
@@ -37,29 +37,18 @@ public class ClassificationConfigurationMaterializer {
     }
 
     public ClassificationConfigurationDescriptor materialize(ClassificationConfigurationXmlMapper mapper) {
-        this.xoManager.currentTransaction().begin();
         ClassificationConfigurationDescriptor classificationConfigurationDescriptor =
             this.xoManager.create(ClassificationConfigurationDescriptor.class);
         // materialize all simple fields
-        for (Field f : mapper.getClass().getDeclaredFields()) {
-            f.setAccessible(true);
-            if (!f.getName().equals("definedComponents")) {
-                char[] setterName = ("set" + f.getName()).toCharArray();
-                setterName[2] = Character.toUpperCase(setterName[2]);
-                try {
-                    Method setter = classificationConfigurationDescriptor.getClass().getMethod(new String(setterName), f.getType());
-                    setter.setAccessible(true);
-                    setter.invoke(classificationConfigurationDescriptor, f.get(mapper));
-                    setter.setAccessible(false);
-                } catch (NoSuchMethodException e) {
-                    throw new MethodNotFoundException(classificationConfigurationDescriptor.getClass().getName() +
-                        "has no setter for field " + f.getName() + "(" + new String(setterName) + "(" + f.getType().getName() + "))");
-                } catch (IllegalAccessException | InvocationTargetException e) {
-                    e.printStackTrace();
-                }
-            }
-            f.setAccessible(false);
-        }
+        classificationConfigurationDescriptor.setIteration(mapper.iteration);
+        classificationConfigurationDescriptor.setBasePackage(mapper.basePackage);
+        classificationConfigurationDescriptor.setTypeName(mapper.typeName);
+        classificationConfigurationDescriptor.setArtifact(mapper.artifact);
+        classificationConfigurationDescriptor.setGenerations(mapper.generations);
+        classificationConfigurationDescriptor.setPopulationSize(mapper.populationSize);
+        classificationConfigurationDescriptor.setDecomposition(mapper.decomposition);
+        classificationConfigurationDescriptor.setOptimization(mapper.optimization);
+
         // materialize components
         Set<ComponentDescriptor> componentDescriptors = mapper.getDefinedComponents().stream()
             .map(m -> (ComponentDescriptor) genericMaterialize(m))
@@ -76,7 +65,6 @@ public class ClassificationConfigurationMaterializer {
             RuleBasedCriterionDescriptor<RuleDescriptor> classificationCriterion = this.xoManager.create(k);
             classificationCriterion.getRules().addAll(v);
         });
-        this.xoManager.currentTransaction().commit();
         return classificationConfigurationDescriptor;
     }
 

--- a/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationXmlMapper.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationXmlMapper.java
@@ -1,13 +1,14 @@
 package com.buschmais.sarf.framework.configuration;
 
+import java.util.HashSet;
+import java.util.Set;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
 import com.buschmais.sarf.framework.metamodel.ComponentXmlMapper;
 import com.buschmais.sarf.plugin.api.Materializable;
 import com.buschmais.sarf.plugin.api.XmlMapper;
-import lombok.Getter;
-
-import javax.xml.bind.annotation.*;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * @author Stephan Pirnbaum
@@ -19,7 +20,6 @@ public class ClassificationConfigurationXmlMapper implements XmlMapper{
     @XmlAttribute(name = "iteration")
     public Integer iteration;
 
-    @Getter
     @XmlAttribute(name = "basePackage")
     public String basePackage;
 
@@ -41,7 +41,6 @@ public class ClassificationConfigurationXmlMapper implements XmlMapper{
     @XmlAttribute(name = "optimization")
     public Optimization optimization;
 
-    @Getter
     @XmlElement(name = "Component")
     public Set<ComponentXmlMapper> definedComponents = new HashSet<>();
 

--- a/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationXmlMapper.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/ClassificationConfigurationXmlMapper.java
@@ -16,51 +16,33 @@ import java.util.Set;
 @Materializable(ClassificationConfigurationDescriptor.class)
 public class ClassificationConfigurationXmlMapper implements XmlMapper{
 
-    @XmlType
-    @XmlEnum
-    public enum Decomposition {
-        @XmlEnumValue("flat")
-        FLAT,
-        @XmlEnumValue("deep")
-        DEEP;
-    }
-
-    @XmlType
-    @XmlEnum
-    public enum Optimization {
-        @XmlEnumValue("similarity")
-        SIMILARITY,
-        @XmlEnumValue("coupling")
-        COUPLING
-    }
-
     @XmlAttribute(name = "iteration")
-    Integer iteration;
+    public Integer iteration;
 
     @Getter
     @XmlAttribute(name = "basePackage")
-    String basePackage;
+    public String basePackage;
 
     @XmlAttribute(name = "typeName")
-    String typeName;
+    public String typeName;
 
     @XmlAttribute(name = "artifact")
-    String artifact;
+    public String artifact;
 
     @XmlAttribute(name = "generations")
-    Integer generations;
+    public Integer generations;
 
     @XmlAttribute(name = "populationSize")
-    Integer populationSize;
+    public Integer populationSize;
 
     @XmlAttribute(name = "decomposition")
-    private Decomposition decomposition;
+    public Decomposition decomposition;
 
     @XmlAttribute(name = "optimization")
-    private Optimization optimization;
+    public Optimization optimization;
 
     @Getter
     @XmlElement(name = "Component")
-    Set<ComponentXmlMapper> definedComponents = new HashSet<>();
+    public Set<ComponentXmlMapper> definedComponents = new HashSet<>();
 
 }

--- a/src/main/java/com/buschmais/sarf/framework/configuration/Decomposition.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/Decomposition.java
@@ -1,0 +1,12 @@
+package com.buschmais.sarf.framework.configuration;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType
+@XmlEnum
+public enum Decomposition {
+    @XmlEnumValue("flat") FLAT,
+    @XmlEnumValue("deep") DEEP
+}

--- a/src/main/java/com/buschmais/sarf/framework/configuration/Optimization.java
+++ b/src/main/java/com/buschmais/sarf/framework/configuration/Optimization.java
@@ -1,0 +1,12 @@
+package com.buschmais.sarf.framework.configuration;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType
+@XmlEnum
+public enum Optimization {
+    @XmlEnumValue("similarity") SIMILARITY,
+    @XmlEnumValue("coupling") COUPLING
+}

--- a/src/main/java/com/buschmais/sarf/framework/ui/ConfigurationDialogController.java
+++ b/src/main/java/com/buschmais/sarf/framework/ui/ConfigurationDialogController.java
@@ -1,6 +1,9 @@
 package com.buschmais.sarf.framework.ui;
 
 import com.buschmais.sarf.framework.ClassificationRunner;
+import com.buschmais.sarf.framework.configuration.ClassificationConfigurationXmlMapper;
+import com.buschmais.sarf.framework.configuration.Decomposition;
+import com.buschmais.sarf.framework.configuration.Optimization;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -72,16 +75,23 @@ public class ConfigurationDialogController extends AbstractController {
     private void execute() {
         this.execute.setDisable(true);
         try {
-            this.classificationRunner.startNewIteration(
-                    1, this.artifact.getText(), this.basePackage.getText(), this.typeName.getText(),
-                    Integer.valueOf(this.generations.getText()), Integer.valueOf(this.populationSize.getText()), true, false
-            );
+            ClassificationConfigurationXmlMapper classificationConfiguration =
+                new ClassificationConfigurationXmlMapper();
+            classificationConfiguration.iteration = 1;
+            classificationConfiguration.artifact = this.artifact.getText();
+            classificationConfiguration.basePackage = this.basePackage.getText();
+            classificationConfiguration.typeName = this.typeName.getText();
+            classificationConfiguration.generations = Integer.valueOf(this.generations.getText());
+            classificationConfiguration.populationSize = Integer.valueOf(this.populationSize.getText());
+            classificationConfiguration.decomposition = Decomposition.DEEP;
+            classificationConfiguration.optimization = Optimization.COUPLING;
+
+            this.classificationRunner.startNewIteration(classificationConfiguration);
         } catch (Exception e) {
             e.printStackTrace();
             showExceptionDialog("Execution Error", "An error occured during decomposing the system!", "", e);
         }
         this.execute.setDisable(false);
     }
-
 
 }

--- a/src/main/java/com/buschmais/sarf/plugin/cohesion/CohesionCriterionExecutor.java
+++ b/src/main/java/com/buschmais/sarf/plugin/cohesion/CohesionCriterionExecutor.java
@@ -3,6 +3,8 @@ package com.buschmais.sarf.plugin.cohesion;
 import com.buschmais.jqassistant.plugin.java.api.model.TypeDescriptor;
 import com.buschmais.sarf.framework.configuration.ClassificationConfigurationDescriptor;
 import com.buschmais.sarf.framework.configuration.ClassificationConfigurationRepository;
+import com.buschmais.sarf.framework.configuration.Decomposition;
+import com.buschmais.sarf.framework.configuration.Optimization;
 import com.buschmais.sarf.framework.metamodel.ComponentDescriptor;
 import com.buschmais.sarf.framework.repository.ComponentRepository;
 import com.buschmais.sarf.framework.repository.TypeRepository;
@@ -46,8 +48,8 @@ public final class CohesionCriterionExecutor implements ClassificationCriterionE
             this.xOManager.getRepository(ClassificationConfigurationRepository.class);
         ClassificationConfigurationDescriptor currentConfiguration = classificationConfigurationRepository.getCurrentConfiguration();
         Integer iteration = currentConfiguration.getIteration();
-        boolean similarityBased = currentConfiguration.getOptimization().equals("similarity");
-        boolean hierarchical = currentConfiguration.getDecomposition().equals("deep");
+        boolean similarityBased = currentConfiguration.getOptimization() == Optimization.SIMILARITY;
+        boolean hierarchical = currentConfiguration.getDecomposition() == Decomposition.DEEP;
         Integer generations = currentConfiguration.getGenerations();
         Integer populationSize = currentConfiguration.getPopulationSize();
         Map<Long, Set<Long>> components = null; // todo get from database

--- a/src/main/java/com/buschmais/sarf/plugin/cohesion/evolution/Partitioner.java
+++ b/src/main/java/com/buschmais/sarf/plugin/cohesion/evolution/Partitioner.java
@@ -75,6 +75,7 @@ public class Partitioner {
                         return s1;
                     });
         }
+        System.out.print("\n");
         return identifiedComponents;
 
     }


### PR DESCRIPTION
Also streamlined preparation & configuration code and made sure that both runners call the same pieces of code (most notably resetting the SARF data before a new run).
This is an important prerequisite for passing a-priori knowledge to the CLI runner.